### PR TITLE
feat(shared): add WebSocket event types, Message, Session, and Partic…

### DIFF
--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -1,1 +1,15 @@
-export {};
+export {
+  WsEvent,
+  type Participant,
+  type Session,
+  type Message,
+  type MessageRole,
+  type JoinPayload,
+  type LeavePayload,
+  type MessagePayload,
+  type TypingPayload,
+  type AiChunkPayload,
+  type ErrorPayload,
+  type PresencePayload,
+  type WsPayload,
+} from "./types.js";

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -1,0 +1,85 @@
+export interface Participant {
+  id: string;
+  name: string;
+  connectedAt: string;
+}
+
+export interface Session {
+  id: string;
+  title: string | null;
+  createdAt: string;
+  participants: Participant[];
+}
+
+export type MessageRole = "user" | "assistant";
+
+export interface Message {
+  id: string;
+  sessionId: string;
+  senderId: string;
+  senderName: string;
+  content: string;
+  role: MessageRole;
+  createdAt: string;
+}
+
+export enum WsEvent {
+  Join = "join",
+  Leave = "leave",
+  Message = "message",
+  Typing = "typing",
+  AiChunk = "ai-chunk",
+  Error = "error",
+  Presence = "presence",
+}
+
+export interface JoinPayload {
+  type: WsEvent.Join;
+  sessionId: string;
+  participant: Participant;
+}
+
+export interface LeavePayload {
+  type: WsEvent.Leave;
+  sessionId: string;
+  participantId: string;
+}
+
+export interface MessagePayload {
+  type: WsEvent.Message;
+  message: Message;
+}
+
+export interface TypingPayload {
+  type: WsEvent.Typing;
+  sessionId: string;
+  participantId: string;
+  isTyping: boolean;
+}
+
+export interface AiChunkPayload {
+  type: WsEvent.AiChunk;
+  sessionId: string;
+  token: string;
+}
+
+export interface ErrorPayload {
+  type: WsEvent.Error;
+  code: string;
+  message: string;
+}
+
+export interface PresencePayload {
+  type: WsEvent.Presence;
+  sessionId: string;
+  participants: Participant[];
+}
+
+export type WsPayload =
+  | JoinPayload
+  | LeavePayload
+  | MessagePayload
+  | TypingPayload
+  | AiChunkPayload
+  | ErrorPayload
+  | PresencePayload;


### PR DESCRIPTION
Defines the shared type contract between server and client: WsEvent enum, typed payloads for join/leave/message/typing/ai-chunk/error/presence, and core domain types (Message, Session, Participant).

Closes #4