### PR TITLE
feat: rate limiting per WebSocket connection (#20)

### DIFF
--- a/packages/server/src/app.test.ts
+++ b/packages/server/src/app.test.ts
@@ -15,6 +15,7 @@ import {
   getHeartbeatConfig,
   setHeartbeatConfig,
 } from "./services/heartbeat";
+import { clearAllRateLimits } from "./services/rate-limit";
 import { clearAllDisconnected, setGracePeriod } from "./services/reconnection";
 import {
   createSession,
@@ -109,6 +110,7 @@ afterEach(async () => {
   clearAllTyping();
   clearAllHeartbeats();
   clearAllDisconnected();
+  clearAllRateLimits();
   await app.close();
 });
 

--- a/packages/server/src/routes/ws.ts
+++ b/packages/server/src/routes/ws.ts
@@ -10,6 +10,7 @@ import {
 } from "../controllers/ws.controller";
 import { addConnection, removeConnection } from "../services/connections";
 import { startHeartbeat, stopHeartbeat } from "../services/heartbeat";
+import { clearRateLimit, isRateLimited } from "../services/rate-limit";
 
 export async function wsRoute(server: FastifyInstance): Promise<void> {
   server.get("/ws", { websocket: true }, (socket, _req) => {
@@ -34,6 +35,20 @@ export async function wsRoute(server: FastifyInstance): Promise<void> {
         return;
       }
 
+      if (
+        (data.type === WsEvent.Message || data.type === WsEvent.Typing) &&
+        isRateLimited(conn.id)
+      ) {
+        log.warn({ connectionId: conn.id }, "rate limited");
+        const errorPayload: WsPayload = {
+          type: WsEvent.Error,
+          code: "RATE_LIMITED",
+          message: "Rate limit exceeded. Please slow down.",
+        };
+        socket.send(JSON.stringify(errorPayload));
+        return;
+      }
+
       switch (data.type) {
         case WsEvent.Join:
           handleJoin(conn, data, log);
@@ -55,6 +70,7 @@ export async function wsRoute(server: FastifyInstance): Promise<void> {
 
     socket.on("close", () => {
       stopHeartbeat(conn.id);
+      clearRateLimit(conn.id);
       handleLeave(conn, log);
       removeConnection(conn.id);
       log.debug("ws connection closed");
@@ -63,6 +79,7 @@ export async function wsRoute(server: FastifyInstance): Promise<void> {
     socket.on("error", (err) => {
       log.error({ err }, "ws connection error");
       stopHeartbeat(conn.id);
+      clearRateLimit(conn.id);
       handleLeave(conn, log);
       removeConnection(conn.id);
     });

--- a/packages/server/src/services/rate-limit.test.ts
+++ b/packages/server/src/services/rate-limit.test.ts
@@ -1,0 +1,78 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  clearAllRateLimits,
+  clearRateLimit,
+  isRateLimited,
+  setRateLimitConfig,
+} from "./rate-limit";
+
+beforeEach(() => {
+  setRateLimitConfig(5, 1000);
+  clearAllRateLimits();
+  vi.useFakeTimers();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("rate limiting", () => {
+  it("allows messages under the limit", () => {
+    for (let i = 0; i < 5; i++) {
+      expect(isRateLimited("conn-1")).toBe(false);
+    }
+  });
+
+  it("blocks messages over the limit", () => {
+    for (let i = 0; i < 5; i++) {
+      isRateLimited("conn-1");
+    }
+    expect(isRateLimited("conn-1")).toBe(true);
+  });
+
+  it("uses a sliding window that expires old entries", () => {
+    for (let i = 0; i < 5; i++) {
+      isRateLimited("conn-1");
+    }
+    expect(isRateLimited("conn-1")).toBe(true);
+
+    vi.advanceTimersByTime(1001);
+
+    expect(isRateLimited("conn-1")).toBe(false);
+  });
+
+  it("tracks connections independently", () => {
+    for (let i = 0; i < 5; i++) {
+      isRateLimited("conn-1");
+    }
+    expect(isRateLimited("conn-1")).toBe(true);
+    expect(isRateLimited("conn-2")).toBe(false);
+  });
+
+  it("clears state for a specific connection", () => {
+    for (let i = 0; i < 5; i++) {
+      isRateLimited("conn-1");
+    }
+    expect(isRateLimited("conn-1")).toBe(true);
+
+    clearRateLimit("conn-1");
+    expect(isRateLimited("conn-1")).toBe(false);
+  });
+
+  it("slides the window correctly with staggered messages", () => {
+    for (let i = 0; i < 3; i++) {
+      isRateLimited("conn-1");
+    }
+
+    vi.advanceTimersByTime(600);
+
+    for (let i = 0; i < 2; i++) {
+      isRateLimited("conn-1");
+    }
+    expect(isRateLimited("conn-1")).toBe(true);
+
+    vi.advanceTimersByTime(500);
+
+    expect(isRateLimited("conn-1")).toBe(false);
+  });
+});

--- a/packages/server/src/services/rate-limit.ts
+++ b/packages/server/src/services/rate-limit.ts
@@ -1,0 +1,52 @@
+const DEFAULT_MAX_MESSAGES = 30;
+const DEFAULT_WINDOW_MS = 10_000;
+
+let _maxMessages = Number(process.env.RATE_LIMIT_MAX) || DEFAULT_MAX_MESSAGES;
+let _windowMs = Number(process.env.RATE_LIMIT_WINDOW_MS) || DEFAULT_WINDOW_MS;
+
+const timestamps = new Map<string, number[]>();
+
+export function setRateLimitConfig(
+  maxMessages: number,
+  windowMs: number,
+): void {
+  _maxMessages = maxMessages;
+  _windowMs = windowMs;
+}
+
+export function getRateLimitConfig(): {
+  maxMessages: number;
+  windowMs: number;
+} {
+  return { maxMessages: _maxMessages, windowMs: _windowMs };
+}
+
+export function isRateLimited(connectionId: string): boolean {
+  const now = Date.now();
+  const cutoff = now - _windowMs;
+
+  let entries = timestamps.get(connectionId);
+  if (!entries) {
+    entries = [];
+    timestamps.set(connectionId, entries);
+  }
+
+  while (entries.length > 0 && entries[0] <= cutoff) {
+    entries.shift();
+  }
+
+  if (entries.length >= _maxMessages) {
+    return true;
+  }
+
+  entries.push(now);
+  return false;
+}
+
+export function clearRateLimit(connectionId: string): void {
+  timestamps.delete(connectionId);
+}
+
+export function clearAllRateLimits(): void {
+  timestamps.clear();
+}


### PR DESCRIPTION
## Summary

- Add in-memory sliding window rate limiter per WebSocket connection (no external dependencies)
- Default: 30 messages per 10 seconds, configurable via `RATE_LIMIT_MAX` and `RATE_LIMIT_WINDOW_MS` env vars
- Rate-limited messages/typing events are dropped with a `RATE_LIMITED` error event sent back to the sender - connection stays open
- Rate limit state is cleaned up on connection close/error
- 6 unit tests covering under-limit, over-limit, sliding window expiry, per-connection isolation, cleanup, and staggered messages

Closes #20

## Test plan

- [ ] Send messages under the limit - all should be delivered
- [ ] Send messages over the limit - sender receives `RATE_LIMITED` error, message is dropped
- [ ] Wait for the window to expire - messages should be allowed again
- [ ] Verify typing events are also rate-limited
- [ ] Verify join/leave/reconnect events are NOT rate-limited
- [ ] Disconnect and reconnect - rate limit state should be fresh
- [ ] Run `pnpm --filter @duet/server test` - all 60 tests pass